### PR TITLE
Separate the ELB subnet at existing VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Array<{
         securityGroupIds: string[]
         subnetIds: string[]
         //If not specified, subnetIds will be used
-        elbSubnetIds: string[]
+        elbSubnetIds?: string[]
     };
     services: Array<{
         name: string; // name of the service

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Array<{
         vpcId: string;
         securityGroupIds: string[]
         subnetIds: string[]
+        //If not specified, subnetIds will be used
+        elbSubnetIds: string[]
     };
     services: Array<{
         name: string; // name of the service

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,7 +6,7 @@ export interface IVPCOptions {
     vpcId: string;
     securityGroupIds: string[];
     subnetIds: string[];
-    elbSubnetIds: string[];
+    elbSubnetIds?: string[];
 }
 
 export interface IServiceProtocolOptions {

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,7 @@ export interface IVPCOptions {
     vpcId: string;
     securityGroupIds: string[];
     subnetIds: string[];
+    elbSubnetIds: string[];
 }
 
 export interface IServiceProtocolOptions {

--- a/src/resources/loadBalancer.ts
+++ b/src/resources/loadBalancer.ts
@@ -33,7 +33,7 @@ export class LoadBalancer extends Resource<IClusterOptions> {
                                     "Value": (this.options.timeout || 30)
                                 }
                             ],
-                            "Subnets": this.cluster.getVPC().getSubnets(),
+                            "Subnets": this.cluster.getVPC().getELBSubnets(),
                             "SecurityGroups": this.getELBSecurityGroupsRef()
                         },
                     },

--- a/src/resources/vpc.ts
+++ b/src/resources/vpc.ts
@@ -37,6 +37,10 @@ export class VPC extends Resource<IVPCOptions> {
         })));
     }
 
+    public getELBSubnets(): any[] {
+        return ((this.useExistingVPC() && this.options.elbSubnetIds.length > 0) ? this.options.elbSubnetIds : this.getSubnets());
+    }
+
     public generate(): any {
         const vpc: string = this.options.cidr;
         const subnets: string[] = this.options.subnets;


### PR DESCRIPTION
Hi @gwdp 

I will a request to separate the ELB subnet in the existing VPC.
For example, Fargate is a private subnet and ELB is a public subnet.